### PR TITLE
Fix loaded sounds not being written correctly in IW4

### DIFF
--- a/src/IW4/Assets/LoadedSound.cpp
+++ b/src/IW4/Assets/LoadedSound.cpp
@@ -57,7 +57,7 @@ namespace ZoneTool
 
 			char* data;
 
-			while (!result->sound.soundData && !feof(fp))
+			while (!result->sound.data && !feof(fp))
 			{
 				fread(&chunkIDBuffer, 4, 1, fp);
 				fread(&chunkSize, 4, 1, fp);
@@ -74,26 +74,26 @@ namespace ZoneTool
 							fclose(fp);
 							return nullptr;
 						}
-						result->sound.waveFormat = format;
+						result->sound.info.format = format;
 
 						short numChannels;
 						fread(&numChannels, 2, 1, fp);
-						result->sound.channelCount = numChannels;
+						result->sound.info.channels = numChannels;
 
 						int sampleRate;
 						fread(&sampleRate, 4, 1, fp);
-						result->sound.sampleRate = sampleRate;
+						result->sound.info.rate = sampleRate;
 
 						int byteRate;
 						fread(&byteRate, 4, 1, fp);
 
 						short blockAlign;
 						fread(&blockAlign, 2, 1, fp);
-						result->sound.blockAlign = blockAlign;
+						result->sound.info.block_size = blockAlign;
 
 						short bitPerSample;
 						fread(&bitPerSample, 2, 1, fp);
-						result->sound.bitPerChannel = bitPerSample;
+						result->sound.info.bits = bitPerSample;
 
 						if (chunkSize > 16)
 						{
@@ -103,10 +103,10 @@ namespace ZoneTool
 					break;
 
 				case 0x61746164: // data
-					result->sound.dataLength = chunkSize;
-					data = (char*)malloc(result->sound.dataLength);
-					fread(data, 1, result->sound.dataLength, fp);
-					result->sound.soundData = data;
+					result->sound.info.data_len = chunkSize;
+					data = (char*)malloc(result->sound.info.data_len);
+					fread(data, 1, result->sound.info.data_len, fp);
+					result->sound.data = data;
 					break;
 
 				default:
@@ -118,7 +118,7 @@ namespace ZoneTool
 				}
 			}
 
-			if (!result->sound.soundData)
+			if (!result->sound.data)
 			{
 				ZONETOOL_ERROR("%s: Could not read sounddata.", name.c_str());
 				fclose(fp);
@@ -173,11 +173,11 @@ namespace ZoneTool
 
 			buf->push_stream(0);
 
-			if (data->sound.soundData)
+			if (data->sound.data)
 			{
 				buf->align(0);
-				buf->write(data->sound.soundData, data->sound.dataLength);
-				ZoneBuffer::ClearPointer(&dest->sound.soundData);
+				buf->write(data->sound.data, data->sound.info.data_len);
+				ZoneBuffer::ClearPointer(&dest->sound.data);
 			}
 
 			buf->pop_stream();
@@ -198,7 +198,7 @@ namespace ZoneTool
 
 				// ChunkSize
 				int subchunk1Size = 16;
-				int subchunk2Size = sound->sound.dataLength;
+				int subchunk2Size = sound->sound.info.data_len;
 				int chunkSize = 4 + (8 + subchunk1Size) + (8 + subchunk2Size);
 				fwrite(&chunkSize, 4, 1, fp);
 
@@ -216,27 +216,27 @@ namespace ZoneTool
 				fwrite(&subchunk1Size, 4, 1, fp);
 
 				// AudioFormat
-				short audioFormat = sound->sound.waveFormat;
+				short audioFormat = sound->sound.info.format;
 				fwrite(&audioFormat, 2, 1, fp);
 
 				// NumChannels
-				short numChannels = sound->sound.channelCount;
+				short numChannels = sound->sound.info.channels;
 				fwrite(&numChannels, 2, 1, fp);
 
 				// SampleRate
-				int sampleRate = sound->sound.sampleRate;
+				int sampleRate = sound->sound.info.rate;
 				fwrite(&sampleRate, 4, 1, fp);
 
 				// ByteRate
-				int byteRate = sound->sound.sampleRate * sound->sound.channelCount * sound->sound.bitPerChannel / 8;
+				int byteRate = sound->sound.info.rate * sound->sound.info.channels * sound->sound.info.bits / 8;
 				fwrite(&byteRate, 4, 1, fp);
 
 				// BlockAlign
-				short blockAlign = sound->sound.blockAlign;
+				short blockAlign = sound->sound.info.block_size;
 				fwrite(&blockAlign, 2, 1, fp);
 
 				// BitsPerSample
-				short bitsPerSample = sound->sound.bitPerChannel;
+				short bitsPerSample = sound->sound.info.bits;
 				fwrite(&bitsPerSample, 2, 1, fp);
 
 
@@ -249,7 +249,7 @@ namespace ZoneTool
 				fwrite(&subchunk2Size, 4, 1, fp);
 
 				// Data
-				fwrite(sound->sound.soundData, sound->sound.dataLength, 1, fp);
+				fwrite(sound->sound.data, sound->sound.info.data_len, 1, fp);
 			}
 
 			FileSystem::FileClose(fp);

--- a/src/IW4/Assets/Sound.cpp
+++ b/src/IW4/Assets/Sound.cpp
@@ -214,7 +214,7 @@ namespace ZoneTool
 
 				if (head->volumeFalloffCurve)
 				{
-					zone->AddAssetOfType(sndcurve, head->volumeFalloffCurve->name);
+					zone->AddAssetOfType(sndcurve, head->volumeFalloffCurve->filename);
 				}
 
 				if (head->soundFile)
@@ -302,7 +302,7 @@ namespace ZoneTool
 			if (data->volumeFalloffCurve)
 			{
 				dest->volumeFalloffCurve = reinterpret_cast<SndCurve*>(zone->GetAssetPointer(
-					sndcurve, data->volumeFalloffCurve->name));
+					sndcurve, data->volumeFalloffCurve->filename));
 			}
 
 			if (data->speakerMap)

--- a/src/IW4/Structs.hpp
+++ b/src/IW4/Structs.hpp
@@ -708,33 +708,37 @@ namespace ZoneTool
 		struct SndCurve
 		{
 			const char* filename;
-			const char* name;
 			unsigned __int16 knotCount;
 			vec2_t knots[16];
 		};
 #pragma pack(pop)
 
+        struct _AILSOUNDINFO
+        {
+            int format;
+            const void* data_ptr;
+            unsigned int data_len;
+            unsigned int rate;
+            int bits;
+            int channels;
+            unsigned int samples;
+            unsigned int block_size;
+            const void* initial_ptr;
+        };
+
 		// Loaded sound
 #pragma pack(push, 4)
-		struct LoadedSoundStruct
+		struct MssSound
 		{
-			int waveFormat;
-			int unknown1;
-			int dataLength;
-			int sampleRate;
-			int bitPerChannel;
-			int channelCount;
-			int unknown3;
-			int blockAlign;
-			int unknown5;
-			char* soundData;
+            _AILSOUNDINFO info;
+            char* data;
 		};
 #pragma pack(pop)
 
 		struct LoadedSound
 		{
 			const char* name;
-			LoadedSoundStruct sound;
+            MssSound sound;
 		};
 
 		// Sounds

--- a/src/IW5/Structs.hpp
+++ b/src/IW5/Structs.hpp
@@ -1058,19 +1058,24 @@ namespace ZoneTool
 #pragma pack(pop)
 
 		// Loaded sound
+        struct _AILSOUNDINFO
+        {
+            int format;
+            const void* data_ptr;
+            unsigned int data_len;
+            unsigned int rate;
+            int bits;
+            int channels;
+            unsigned int samples;
+            unsigned int block_size;
+            const void* initial_ptr;
+        };
+
 #pragma pack(push, 4)
 		struct MssSound
 		{
-			int waveFormat; // +0
-			int unknown1; // +4
-			int dataLength; // +8
-			int sampleRate; // +12
-			int bitPerChannel; // +16
-			int channelCount; // +20
-			int unknown3; // +24
-			int blockAlign; // +28
-			int unknown5; // +32
-			char* soundData; // +36
+            _AILSOUNDINFO info;
+            char* data;
 		};
 #pragma pack(pop)
 


### PR DESCRIPTION
The LoadedSound struct is now updated.
The cause of the problem was SndCurves not being written correctly to the zone.

**Important though:**
When building zones for IW4x (in my case mod.ff) no SoundAliases or LoadedSounds can be overwritten!
This means in order to change a sound for a weapon you need to make a new soundalias, a new loadedsound and modify the weapon file of the weapon to use the new soundalias.
*New means you have to pick an assetname that is not contained in a vanilla fastfile.*

refs: #8 