### PR TITLE
Fix IW3 console message when dumping is finished

### DIFF
--- a/src/IW3/IW3.cpp
+++ b/src/IW3/IW3.cpp
@@ -92,6 +92,7 @@ namespace ZoneTool
 					XAsset assetData{asset.first, DB_FindXAssetHeader(asset.first, &asset.second[1])};
 					HandleAsset(&assetData);
 				}
+                ZONETOOL_INFO("Zone \"%s\" dumped.", &fastfile[0]);
 
 				// clear referenced assets array because we are done dumping
 				referencedAssets.clear();
@@ -105,12 +106,6 @@ namespace ZoneTool
 			if (isDumping)
 			{
 				FileSystem::SetFastFile(fastfile);
-
-				// check if we're done loading the fastfile
-				if (asset->type == rawfile && GetAssetName(asset) == fastfile)
-				{
-					ZONETOOL_INFO("Zone \"%s\" dumped.", &fastfile[0]);
-				}
 
 				// check if the asset is a reference asset
 				if (GetAssetName(asset)[0] == ',')

--- a/src/IW3/IW3.cpp
+++ b/src/IW3/IW3.cpp
@@ -86,12 +86,6 @@ namespace ZoneTool
 
 			if (asset->type == rawfile && GetAssetName(asset) == currentDumpingZone)
 			{
-				// dump all referenced assets
-				for (auto& asset : referencedAssets)
-				{
-					XAsset assetData{asset.first, DB_FindXAssetHeader(asset.first, &asset.second[1])};
-					HandleAsset(&assetData);
-				}
                 ZONETOOL_INFO("Zone \"%s\" dumped.", &fastfile[0]);
 
 				// clear referenced assets array because we are done dumping


### PR DESCRIPTION
Also remove dumping of referenced assets due to it leading to being stuck in an infinite loop when calling DB_FindXAssetHeader.

refs: #14