### PR TITLE
Fix XAnims from IW3 not setting the looping flag correctly in IW4/IW5

### DIFF
--- a/src/IW3/Assets/XAnimParts.cpp
+++ b/src/IW3/Assets/XAnimParts.cpp
@@ -29,14 +29,18 @@ namespace ZoneTool
 				XAE_CopyElement(randomDataByteCount);
 				XAE_CopyElement(randomDataIntCount);
 				XAE_CopyElement(framecount);
-				// XAE_CopyElement(pad1);
+
+                asset->flags = 0;
+                if (anim->bLoop)
+                    asset->flags |= IW4::ANIM_LOOP;
+                if (anim->bDelta)
+                    asset->flags |= IW4::ANIM_DELTA;
+
 				for (int i = 0; i < 10; i++)
 					XAE_CopyElement(boneCount[i]);
-				XAE_CopyElement(notetrackCount);
-				XAE_CopyElement(bLoop);
-				XAE_CopyElement(bDelta);
+				XAE_CopyElement(notifyCount);
 				XAE_CopyElement(assetType);
-				// XAE_CopyElement(pad2);
+				XAE_CopyElement(isDefault);
 				XAE_CopyElement(randomDataShortCount);
 				XAE_CopyElement(indexcount);
 				XAE_CopyElement(framerate);
@@ -49,7 +53,7 @@ namespace ZoneTool
 				XAE_CopyElement(randomDataByte);
 				XAE_CopyElement(randomDataInt);
 				XAE_CopyElement(indices.data);
-				asset->notetracks = (IW4::XAnimNotifyInfo*)anim->notetracks;
+				asset->notify = (IW4::XAnimNotifyInfo*)anim->notify;
 				asset->delta = (IW4::XAnimDeltaPart*)anim->delta;
 
 				// dump asset

--- a/src/IW3/Structs.hpp
+++ b/src/IW3/Structs.hpp
@@ -803,13 +803,12 @@ namespace ZoneTool
 			unsigned short randomDataByteCount; // 10 - 0xA
 			unsigned short randomDataIntCount; // 12 - 0xC
 			unsigned short framecount; // 14 - 0xE
-			char pad1; // 16
-			char pad2; // 31
-			char boneCount[10]; // 17
-			char notetrackCount; // 27
-			bool bLoop; // 28
-			bool bDelta; // 29
+			char bLoop; // 16
+			char bDelta; // 31
+			unsigned char boneCount[10]; // 17
+			char notifyCount; // 27
 			char assetType; // 30
+            bool isDefault;
 			unsigned int randomDataShortCount; // 32 - 0x20
 			unsigned int indexcount; // 36 - 0x24
 			float framerate; // 40 - 0x28
@@ -822,7 +821,7 @@ namespace ZoneTool
 			char* randomDataByte; // 68 - 0x44
 			int* randomDataInt; // 72 - 0x48
 			XAnimIndices indices; // 76 - 0x4C
-			XAnimNotifyInfo* notetracks; // 80 - 0x50
+			XAnimNotifyInfo* notify; // 80 - 0x50
 			XAnimDeltaPart* delta; // 84 - 0x54
 		};
 

--- a/src/IW4/Assets/XAnimParts.cpp
+++ b/src/IW4/Assets/XAnimParts.cpp
@@ -45,14 +45,14 @@ namespace ZoneTool::IW4
 		}
 
 		// allocate notetracks
-		xanim->notetracks = mem->Alloc<XAnimNotifyInfo>(xanim->notetrackCount);
-		memcpy(xanim->notetracks, this->m_asset->notetracks, sizeof XAnimNotifyInfo * xanim->notetrackCount);
+		xanim->notify = mem->Alloc<XAnimNotifyInfo>(xanim->notifyCount);
+		memcpy(xanim->notify, this->m_asset->notify, sizeof XAnimNotifyInfo * xanim->notifyCount);
 
 		// touch XAnimNotifyInfo, realloc tagnames
-		for (auto i = 0; i < xanim->notetrackCount; i++)
+		for (auto i = 0; i < xanim->notifyCount; i++)
 		{
-			const std::string bone = SL_ConvertToString(this->m_asset->notetracks[i].name);
-			xanim->notetracks[i].name = buf->write_scriptstring(bone);
+			const std::string bone = SL_ConvertToString(this->m_asset->notify[i].name);
+			xanim->notify[i].name = buf->write_scriptstring(bone);
 		}
 
 		this->m_asset = xanim;
@@ -88,10 +88,10 @@ namespace ZoneTool::IW4
 			buf->write_stream(data->tagnames, sizeof(short), data->boneCount[9]);
 			dest->tagnames = reinterpret_cast<unsigned short*>(-1);
 		}
-		if (data->notetracks) // notetracks
+		if (data->notify) // notify
 		{
 			buf->align(3);
-			buf->write_stream(data->notetracks, sizeof(XAnimNotifyInfo), data->notetrackCount);
+			buf->write_stream(data->notify, sizeof(XAnimNotifyInfo), data->notifyCount);
 			dest->tagnames = reinterpret_cast<unsigned short*>(-1);
 		}
 

--- a/src/IW4/Structs.hpp
+++ b/src/IW4/Structs.hpp
@@ -1941,6 +1941,13 @@ namespace ZoneTool
 			float time;
 		};
 
+        enum XAnimPartsFlags
+        {
+            ANIM_LOOP = 0x1,
+            ANIM_DELTA = 0x2,
+            ANIM_DELTA_3D = 0x4,
+        };
+
 		struct XAnimParts
 		{
 			char* name; // 0
@@ -1952,11 +1959,9 @@ namespace ZoneTool
 			unsigned short framecount; // 14 - 0xE
 			char flags; // 16
 			unsigned char boneCount[10]; // 17
-			char notetrackCount; // 27
-			bool bLoop; // 28
-			bool bDelta; // 29
+			char notifyCount; // 27
 			char assetType; // 30
-			char ikType; // 31
+			bool isDefault; // 31
 			unsigned int randomDataShortCount; // 32 - 0x20
 			unsigned int indexcount; // 36 - 0x24
 			float framerate; // 40 - 0x28
@@ -1969,7 +1974,7 @@ namespace ZoneTool
 			char* randomDataByte; // 68 - 0x44
 			int* randomDataInt; // 72 - 0x48
 			XAnimIndices indices; // 76 - 0x4C
-			XAnimNotifyInfo* notetracks; // 80 - 0x50
+			XAnimNotifyInfo* notify; // 80 - 0x50
 			XAnimDeltaPart* delta; // 84 - 0x54
 		};
 #pragma pack(pop)


### PR DESCRIPTION
While looping animations have a boolean value in IW3, they just set a flag in IW4 and IW5. This needs to be handled correctly when porting XAnims from IW3 to IW4/IW5.

Also now handles the delta flag correctly. Not sure what it does exactly though.

refs: #25 