### PR TITLE
Fix zone csv not being created when dumping more than 1 zone

### DIFF
--- a/src/IW4/IW4.cpp
+++ b/src/IW4/IW4.cpp
@@ -193,11 +193,12 @@ char**>(0x00799278)[type]);
 			auto fastfile = static_cast<std::string>((char*)(*(DWORD*)0x112A680 + 4));
 
 			// generate CSV for fastfile
+			static FILE* csvFile = nullptr;
+
 			if (isVerifying || isDumping)
 			{
 				FileSystem::SetFastFile(fastfile);
 
-				static FILE* csvFile;
 
 				// open csv file for dumping 
 				if (!csvFile)
@@ -246,6 +247,10 @@ char**>(0x00799278)[type]);
 
 					// clear referenced assets array because we are done dumping
 					referencedAssets.clear();
+
+					// clear csv file static variable for next dumps
+					FileSystem::FileClose(csvFile);
+					csvFile = nullptr;
 
 					// mark dumping as complete to exit the process if it has been started using the command line
 					if (currentDumpingZone == fastfile)

--- a/src/IW5/Patches/AssetHandler.cpp
+++ b/src/IW5/Patches/AssetHandler.cpp
@@ -124,7 +124,7 @@ namespace ZoneTool
 			{
 				FileSystem::SetFastFile(fastfile);
 
-				static FILE* csvFile;
+				static FILE* csvFile = nullptr;
 
 				// open csv file for dumping 
 				if (!csvFile)
@@ -167,6 +167,7 @@ namespace ZoneTool
 
 					referencedAssets.clear();
 					FileSystem::FileClose(csvFile);
+					csvFile = nullptr;
 
 					is_dumping_complete = true;
 				}


### PR DESCRIPTION
The csvFile static variable was not properly cleared after dumping the first zone and was blocking the creation of the zone csv files for next dumpzone commands.