### PR TITLE
Fix uncompressed rawfiles not being dumped

### DIFF
--- a/src/IW4/Assets/RawFile.cpp
+++ b/src/IW4/Assets/RawFile.cpp
@@ -122,7 +122,7 @@ namespace ZoneTool
 
 			if (fp)
 			{
-				if (asset->compressedLen)
+				if (asset->compressedLen > 0)
 				{
 					std::vector<std::uint8_t> uncompressed;
 					uncompressed.resize(asset->len);
@@ -131,6 +131,10 @@ namespace ZoneTool
 					                         asset->compressedLen);
 
 					fwrite(uncompressed.data(), uncompressed.size(), 1, fp);
+				}
+				else if (asset->len > 0)
+				{
+					fwrite(asset->buffer, asset->len, 1, fp);
 				}
 			}
 

--- a/src/IW5/Assets/RawFile.cpp
+++ b/src/IW5/Assets/RawFile.cpp
@@ -110,7 +110,7 @@ namespace ZoneTool
 
 			if (fp)
 			{
-				if (asset->compressedLen)
+				if (asset->compressedLen > 0)
 				{
 					std::vector<std::uint8_t> uncompressed;
 					uncompressed.resize(asset->len);
@@ -119,6 +119,10 @@ namespace ZoneTool
 					                         asset->compressedLen);
 
 					fwrite(uncompressed.data(), uncompressed.size(), 1, fp);
+				}
+				else if (asset->len > 0)
+				{
+					fwrite(asset->buffer, asset->len, 1, fp);
 				}
 			}
 


### PR DESCRIPTION
The dump method was only handling compressed rawfiles.