### PR TITLE
Adjust IW4 xmodel bones for shield hits

### DIFF
--- a/src/IW4/Assets/Xmodel.cpp
+++ b/src/IW4/Assets/Xmodel.cpp
@@ -153,9 +153,23 @@ namespace ZoneTool
 
 			if (data->partClassification)
 			{
+				char *shieldAdjustedPartClassification = new char[data->numBones];
+
+				for (int i = 0; i < data->numBones; i++)
+				{
+					uint16_t boneNameIndex = data->boneNames[i];
+					std::string boneNameString = buf->get_scriptstring(boneNameIndex);
+					if (boneNameString == "tag_shield_back" || boneNameString == "tag_weapon_left")
+						shieldAdjustedPartClassification[i] = 0x13;
+					else
+						shieldAdjustedPartClassification[i] = data->partClassification[i];
+				}
+
 				buf->align(0);
-				buf->write(data->partClassification, data->numBones);
+				buf->write(shieldAdjustedPartClassification, data->numBones);
+
 				ZoneBuffer::clear_pointer(&dest->partClassification);
+				delete[] shieldAdjustedPartClassification;
 			}
 
 			if (data->animMatrix)


### PR DESCRIPTION
Credit to @K0bin, who helped me scriptkiddie my way through C++.

This might suck but what it does is modify xmodels that when they are built into a fastfile for IW4, bones are mapped to the correct hit locations for riot shield hits.

Thanks to @Laupetin! 

![Discord Log](https://user-images.githubusercontent.com/21311428/137806191-d9aa0835-24fc-4fa1-9df3-acbe25ee8dea.png)